### PR TITLE
gsm8k cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ datasets/mmlu_questions_train.json
 *.json.gz
 env/
 src/*.egg-info/*
+src/promptbase/generations/*
+datasets/*
+*.log
+*.jsonl

--- a/src/promptbase/__main__.py
+++ b/src/promptbase/__main__.py
@@ -5,7 +5,7 @@ from promptbase.math import math
 from promptbase.drop import drop
 from promptbase.bigbench import bigbench
 
-VALID_DATASETS = ["gsm8k", "humaneval", "math", "drop"]
+VALID_DATASETS = ["gsm8k", "humaneval", "math", "drop", "bigbench"]
 
 
 def parse_arguments():

--- a/src/promptbase/generations/README.md
+++ b/src/promptbase/generations/README.md
@@ -1,0 +1,3 @@
+# About
+
+This directory is used to store any generated output from language models. For example, intermediate results from chain-of-thought prompting could be stored here.

--- a/src/promptbase/gsm8k/gsm8k.py
+++ b/src/promptbase/gsm8k/gsm8k.py
@@ -57,7 +57,7 @@ def solve(task):
             break
 
     if answer:
-        with open(my_path.parent / "datasets" / "gsm8k.jsonl", "a") as f:
+        with open(my_path.parent / "generations" / "gsm8k.jsonl", "a") as f:
             f.write(json.dumps({"idx": idx, "answer": answer, "proof": text}) + "\n")
 
 
@@ -76,7 +76,7 @@ def generate():
 def evaluate():
     rows = []
     ds = load_dataset("gsm8k", "main")["test"]
-    with open(my_path.parent / "datasets" / "gsm8k.jsonl", "r") as f:
+    with open(my_path.parent / "generations" / "gsm8k.jsonl", "r") as f:
         for line in f:
             row = json.loads(line)
             row["answer"] = extract_substrings(row["proof"])

--- a/src/promptbase/gsm8k/gsm8k.py
+++ b/src/promptbase/gsm8k/gsm8k.py
@@ -9,16 +9,6 @@ from datasets import load_dataset
 my_path = pathlib.Path(__file__).parent.resolve()
 
 
-def prompt_generator(ds):
-    for idx, row in enumerate(ds):
-        prompt = (
-            row["question"]
-            + "\nPlease end your solution with Answer: $\\boxed{number}$ where number is the numerical answer without unit.\nSolution:"
-        )
-        yield idx, prompt
-
-
-
 def extract_substrings(text):
     parts = text.split(r"\boxed")
     matches = []
@@ -73,8 +63,14 @@ def solve(task):
 
 def generate():
     ds = load_dataset("gsm8k", "main")["test"]
-    generator = prompt_generator(ds)
-    run_batch_jobs(solve, generator, max_thread=20)
+    tasks = []
+    for idx, row in enumerate(ds):
+        prompt = (
+            row["question"]
+            + "\nPlease end your solution with Answer: $\\boxed{number}$ where number is the numerical answer without unit.\nSolution:"
+        )
+        tasks.append((idx, prompt))
+    run_batch_jobs(solve, tasks, max_thread=20)
 
 
 def evaluate():

--- a/src/promptbase/utils/utils.py
+++ b/src/promptbase/utils/utils.py
@@ -15,7 +15,7 @@ openai_configs.endpoints = {
         "url": os.getenv("AZURE_OPENAI_EMBEDDINGS_URL"),
     },
     "azure": {
-        "headers": {"Authorization": f"Bearer {os.getenv('AZURE_OPENAI_CHAT_API_KEY')}"},
+        "headers": {"api-key": f"{os.getenv('AZURE_OPENAI_CHAT_API_KEY')}"},
         "url": os.getenv("AZURE_OPENAI_CHAT_ENDPOINT_URL"),
     }
 }
@@ -71,10 +71,10 @@ def text_completion_impl(
 ):
     """
     Performs text completion using the openai API with
-    - prompt (str or array of str)
+    - prompt (str or array of str messages if chat model)
     - model ("text-davinci-003", "text-davinci-002", ...)
     - tempature (0 for picking the best token, 1 for more creative solution)
-    - max_tokens (limit the total number of generated tokens. 8193 is the maximum context length text-alpha-002)
+    - max_tokens (limit the total number of generated tokens. 8193 is the maximum context length of gpt-4)
     - max_trial (the number of retry after getting rate limited warning, we rethrow for all other errors)
     - logprobs (return a list of the most likely tokens and its probabilites. either integer in [1,5] or None)
     - stop (string or list of string (up to 4 strings). The returned text will not contain the stop sequence.)
@@ -129,7 +129,8 @@ def text_completion_impl(
                 payload["messages"] = payload["prompt"]
                 del payload["prompt"], payload["logprobs"], payload["echo"]
 
-            logging.info("Request:" + str(payload))
+            logging.info("Request URL: " + url)
+            logging.info("Request payload: " + str(payload))
             r = s.post(url, headers=headers, json=payload, timeout=200)
 
             last_response = r.text

--- a/src/promptbase/utils/utils.py
+++ b/src/promptbase/utils/utils.py
@@ -198,7 +198,7 @@ def text_completion(**kwargs):
         )
         message += "########## Response ##########\n"
         message += result.get("text", "NONE") + "\n"
-        with open(kwargs["log_file"], "a") as f:
+        with open(kwargs["log_file"], "a", encoding="utf-8") as f:
             f.write(message)
     return result
 


### PR DESCRIPTION
Fixes needed to make the gsm8k benchmark run against Azure OpenAI GPT-4 chat model.

Also contains some additional small changes:
- Removes the global prompt list in the gsm8k module, making it a scoped variable instead. We'll be doing something similar for the other scripts that followed this pattern.
- Makes `generations/` directory which will be used to store the intermediate outputs moving forward
- Fixes a log file encoding issue
- Adds "bigbench" into the valid datasets list