### PR TITLE
Bigbench - more fixes to replicate original results

### DIFF
--- a/src/promptbase/__main__.py
+++ b/src/promptbase/__main__.py
@@ -22,9 +22,13 @@ def parse_arguments():
     )
     p.add_argument("--subject", type=str, help="Specify the subject for the dataset")
     p.add_argument(
-        "--list_subjects",
-        action="store_true",
-        help="Lists the subjects available for the dataset",
+        "--subject", type=str, help="Specify the subject for the dataset"
+    )
+    p.add_argument(
+        "--mode", type=str, default="chat", choices=["chat", "completion"], help="Prompting mode for the model (chat or completion)"
+    )
+    p.add_argument(
+        "--list_subjects", action='store_true', help="Lists the subjects available for the dataset"
     )
     p.add_argument(
         "--overwrite", action='store_true', help="Overwrites the results of a previous run"
@@ -44,6 +48,8 @@ def main():
             print(f"Dataset {args.dataset} does not have subjects")
         return
 
+    mode = args.mode
+
     if args.dataset == "gsm8k":
         gsm8k.generate()
         gsm8k.evaluate()
@@ -59,7 +65,7 @@ def main():
     elif args.dataset == "bigbench":
         subject = args.subject if args.subject else "all"
         overwrite = args.overwrite
-        bigbench.generate(subject, overwrite)
+        bigbench.generate(subject, overwrite, mode)
         bigbench.evaluate()
     elif args.dataset == "mmlu":
         # Note that to run the MMLU tests, you will need to download the

--- a/src/promptbase/__main__.py
+++ b/src/promptbase/__main__.py
@@ -66,7 +66,7 @@ def main():
         subject = args.subject if args.subject else "all"
         overwrite = args.overwrite
         bigbench.generate(subject, overwrite, mode)
-        bigbench.evaluate()
+        bigbench.evaluate(mode)
     elif args.dataset == "mmlu":
         # Note that to run the MMLU tests, you will need to download the
         # data, and then use the 'format_mmlu.py' script

--- a/src/promptbase/__main__.py
+++ b/src/promptbase/__main__.py
@@ -26,6 +26,9 @@ def parse_arguments():
         action="store_true",
         help="Lists the subjects available for the dataset",
     )
+    p.add_argument(
+        "--overwrite", action='store_true', help="Overwrites the results of a previous run"
+    )
     return p.parse_args()
 
 
@@ -55,7 +58,8 @@ def main():
         drop.evaluate()
     elif args.dataset == "bigbench":
         subject = args.subject if args.subject else "all"
-        bigbench.generate(subject)
+        overwrite = args.overwrite
+        bigbench.generate(subject, overwrite)
         bigbench.evaluate()
     elif args.dataset == "mmlu":
         # Note that to run the MMLU tests, you will need to download the

--- a/src/promptbase/bigbench/bigbench.py
+++ b/src/promptbase/bigbench/bigbench.py
@@ -3,13 +3,13 @@ from .bigbench_score import score
 from .bigbench_answer import process_answers
 from promptbase.bigbench.consts import BIGBENCH_SUBJECTS
 
-def generate(subject: str):
+def generate(subject: str, overwrite: bool):
   if subject != "all" and subject not in BIGBENCH_SUBJECTS:
     print(f"Invalid subject: {subject}")
     return
   print(f"Running BigBench generation for subject {subject}")
-  process_cot(subject)
-  process_answers(subject)
+  process_cot(subject, overwrite)
+  process_answers(subject, overwrite)
 
 def evaluate():
   score()

--- a/src/promptbase/bigbench/bigbench.py
+++ b/src/promptbase/bigbench/bigbench.py
@@ -3,13 +3,13 @@ from .bigbench_score import score
 from .bigbench_answer import process_answers
 from promptbase.bigbench.consts import BIGBENCH_SUBJECTS
 
-def generate(subject: str, overwrite: bool):
+def generate(subject: str, overwrite: bool, mode="chat"):
   if subject != "all" and subject not in BIGBENCH_SUBJECTS:
     print(f"Invalid subject: {subject}")
     return
   print(f"Running BigBench generation for subject {subject}")
-  process_cot(subject, overwrite)
-  process_answers(subject, overwrite)
+  process_cot(subject, overwrite, mode)
+  process_answers(subject, overwrite, mode)
 
-def evaluate():
-  score()
+def evaluate(mode="chat"):
+  score(mode)

--- a/src/promptbase/bigbench/bigbench_answer.py
+++ b/src/promptbase/bigbench/bigbench_answer.py
@@ -846,7 +846,7 @@ def process_completion_answers(subject):
         do_completion_answer(cot_results_path, subject)
 
 
-def process_answers(test_name: str, api_type="chat"):
+def process_answers(test_name: str, overwrite=False, api_type="chat"):
     """
     Processes chain-of-thought answers to produce the label in the expected format.
     """

--- a/src/promptbase/bigbench/bigbench_answer.py
+++ b/src/promptbase/bigbench/bigbench_answer.py
@@ -3,10 +3,6 @@ import copy
 import threading
 from promptbase.utils.helpers import text_completion, get_generations_path, get_standard_logger_for_file
 
-cot_results_dir = get_generations_path() / "bigbench" / "cot_results"
-answers_dir = get_generations_path() / "bigbench" / "answers"
-chat_answers_dir = answers_dir / "chat"
-completion_answers_dir = answers_dir / "completion"
 multiple_choice_instruction = (
     "A multiple choice answer inside parentheses, e.g. (A), and nothing more",
 )
@@ -756,7 +752,11 @@ def do_answer(cot_result_path, answer_results_path):
     _logger.info("Done processing answers for %s", test_name)
 
 
+cot_results_dir = get_generations_path() / "bigbench" / "cot_results"
+answers_dir = get_generations_path() / "bigbench" / "answers"
+
 def process_chat_answers(subject, overwrite):
+    chat_answers_dir = answers_dir / "chat"
     if not chat_answers_dir.exists():
         chat_answers_dir.mkdir(parents=True, exist_ok=True)
     answer_results_path = chat_answers_dir / f"{subject}_chat_answers.json"
@@ -772,13 +772,9 @@ def process_chat_answers(subject, overwrite):
 
 
 def process_completion_answers(subject, overwrite):
-    cot_results_filename = (
-        cot_results_dir / "completion" / f"{subject}_completion_cot_results.json"
-    )
-    if not cot_results_filename.exists():
-        _logger.error(
-            f"COT result file {cot_results_filename} does not exist, skipping"
-        )
+    completion_answers_dir = answers_dir / "completion"
+    if not completion_answers_dir.exists():
+        completion_answers_dir.mkdir(parents=True, exist_ok=True)
     answer_results_path = completion_answers_dir / f"{subject}_completion_answers.json"
     if overwrite and answer_results_path.exists():
         answer_results_path.unlink()

--- a/src/promptbase/bigbench/bigbench_answer.py
+++ b/src/promptbase/bigbench/bigbench_answer.py
@@ -728,6 +728,14 @@ def do_answer(cot_result_path, answer_results_path, mode):
             _logger.info("Skipping answer %s of test %s", i, test_name)
             continue
         prompt_messages = copy.deepcopy(few_shot_examples[test_name])
+        cot_prompt = cot['prompt'].split('\n\nQ:')[-1]
+        qa_prompt = f"Q:{cot_prompt}{cot['completion']}"
+        prompt_messages.append(
+            {
+                "role": "user",
+                "content": qa_prompt,
+            }
+        )
         if mode == "chat":
             prompt_messages.append(
                 {

--- a/src/promptbase/bigbench/bigbench_answer.py
+++ b/src/promptbase/bigbench/bigbench_answer.py
@@ -728,14 +728,6 @@ def do_answer(cot_result_path, answer_results_path, mode):
             _logger.info("Skipping answer %s of test %s", i, test_name)
             continue
         prompt_messages = copy.deepcopy(few_shot_examples[test_name])
-        cot_prompt = cot['prompt'].split('\n\nQ:')[-1]
-        qa_prompt = f"Q:{cot_prompt}{cot['completion']}"
-        prompt_messages.append(
-            {
-                "role": "user",
-                "content": qa_prompt,
-            }
-        )
         if mode == "chat":
             prompt_messages.append(
                 {
@@ -744,10 +736,13 @@ def do_answer(cot_result_path, answer_results_path, mode):
                 }
             )
         elif mode == "completion":
+            # Take out the last question answer pair
+            cot_prompt = cot['prompt'].split('\n\nQ:')[-1]
+            qa_prompt = f"Q:{cot_prompt}{cot['completion']}"
             prompt_messages.append(
                 {
                     "role": "user",
-                    "content": f"{cot['prompt']}\n\n{cot['completion']}",
+                    "content": qa_prompt,
                 }
             )
         try:

--- a/src/promptbase/bigbench/bigbench_cot.py
+++ b/src/promptbase/bigbench/bigbench_cot.py
@@ -62,7 +62,7 @@ def do_chat_cot(bbh_test_path, cot_prompt_path, test_name, cot_results_path):
             prompt_messages = few_shot_messages + [
                 {"role": "user", "content": "Q: " + example["input"]}
             ]
-            response = text_completion(prompt=prompt_messages, max_tokens=2000, retry_wait=2, max_trial=int(1e9), api_type="chat")
+            response = text_completion(prompt=prompt_messages, max_tokens=2000, model="gpt-4-1106-preview", retry_wait=2, max_trial=int(1e9))
             if "text" not in response:
                 _logger.error("Error in example %s of test %s response: %s", i, test_name, response)
                 continue
@@ -100,7 +100,7 @@ def do_completion_cot(bbh_test_path, cot_prompt_path, test_name, cot_results_pat
                 continue
             prompt = f"{cot_prompt_contents}\n\nQ: {example['input']}\nA: Let's think step by step.\n"
             try:
-                response = text_completion(prompt=prompt, max_tokens=2000, retry_wait=2, max_trial=int(1e9), stop="\n\n", api_type="completion")
+                response = text_completion(prompt=prompt, max_tokens=2000, model="gpt4-1106-comp", retry_wait=2, max_trial=int(1e9), stop="\n\n")
                 test_results.append(
                     {
                         "index": i,

--- a/src/promptbase/bigbench/bigbench_cot.py
+++ b/src/promptbase/bigbench/bigbench_cot.py
@@ -17,23 +17,34 @@ _logger = get_standard_logger_for_file(__file__)
 def extract_chat_qa(few_shot_prompt):
     question = few_shot_prompt.split("\nA: ")[0].strip()
     answer = "A: " + few_shot_prompt.split("\nA: ")[1].strip()
-    print("fewshot===")
-    print("Q: ", question)
-    print("A: ", answer)
+    _logger.info("fewshot===")
+    _logger.info("Q: %s", question)
+    _logger.info("A: %s", answer)
     return (question, answer)
 
 
 def do_chat_cot(bbh_test_path, cot_prompt_path, test_name, cot_results_path):
     _logger.info(f"Processing {test_name}")
-    test_results = []
+    cot_results_filename = os.path.join(cot_results_path, f"{test_name}_chat_cot_results.json")
+    if os.path.exists(cot_results_filename):
+        test_results = json.load(open(cot_results_filename, "r"))
+    else:
+        test_results = []
     with open(cot_prompt_path, "r", encoding="utf-8") as file:
-        cot_prompt_contents = file.read()
-        # use everything starting with the third line
-        cot_prompt_contents = "\n".join(cot_prompt_contents.split("\n")[2:])
+        file_contents = file.read()
 
-    few_shots = cot_prompt_contents.split("\n\n")
+        instruction_start_index = file_contents.find('-----')
+        instruction_end_index = file_contents.find('Q:')
+        offset_len = len('-----')
+
+        if instruction_start_index != -1 and instruction_end_index != -1:
+            instruction = file_contents[instruction_start_index+offset_len:instruction_end_index].strip()
+        else:
+            _logger.error(f"Error parsing bigbench cot-prompts in {cot_prompt_path}")
+            instruction = "Answer the following question."
+
+    few_shots = file_contents[instruction_end_index:].split("\n\n")
     # The first shot starts with an instruction, then two newlines, then the first shot
-    instruction = few_shots[0]
     qa_pairs = [extract_chat_qa(few_shot) for few_shot in few_shots[1:]]
     few_shot_messages = [
         {"role": "system", "content": f"{instruction}"},
@@ -49,10 +60,16 @@ def do_chat_cot(bbh_test_path, cot_prompt_path, test_name, cot_results_path):
             _logger.info(
                 f"Processing example {i} of {len(example_data['examples'])} for {test_name}"
             )
+            if any([r["index"] == i for r in test_results]):
+                _logger.info("Skipping example %s of test %s", i, test_name)
+                continue
             prompt_messages = few_shot_messages + [
                 {"role": "user", "content": "Q: " + example["input"]}
             ]
-            response = text_completion(prompt=prompt_messages, temperature=0)
+            response = text_completion(prompt=prompt_messages, retry_wait=2, max_trial=int(1e9))
+            if "text" not in response:
+                _logger.error("Error in example %s of test %s response: %s", i, test_name, response)
+                continue
             test_results.append(
                 {
                     "index": i,
@@ -61,7 +78,6 @@ def do_chat_cot(bbh_test_path, cot_prompt_path, test_name, cot_results_path):
                     "completion": response["text"]
                 }
             )
-            cot_results_filename = os.path.join(cot_results_path, f"{test_name}_chat_cot_results.json")
             json.dump(test_results, open(cot_results_filename, "w"), indent=4)
 
 
@@ -110,7 +126,7 @@ def do_completion_cot(bbh_test_path, cot_prompt_path, test_name, cot_results_pat
                     )
                     break
                 except Exception as e:
-                    _logger.warning("Caught exception: ", e)
+                    _logger.warning("Caught exception: %s", e)
                     _logger.warning("Retrying in 5 seconds...")
                     time.sleep(5)
             cot_results_filename = os.path.join(
@@ -123,7 +139,7 @@ def do_completion_cot(bbh_test_path, cot_prompt_path, test_name, cot_results_pat
             )
 
 
-def process_cot(test_name: str, api_type="chat"):
+def process_cot(test_name: str, overwrite=False, api_type="chat"):
     _logger.info("Starting process_cot")
     if test_name == "all":
         subjects = BIGBENCH_SUBJECTS
@@ -159,6 +175,10 @@ def process_cot(test_name: str, api_type="chat"):
         if api_type == "completion":
             _logger.info(f"Starting completion thread for {bbh_test_path}")
             results_path = generations_dir / "bigbench" / "cot_results" / "completion"
+            if overwrite:
+                cot_results_filename = results_path / f"{subject}_chat_cot_results.json"
+                if os.path.exists(cot_results_filename):
+                    os.remove(cot_results_filename)
             os.makedirs(results_path, exist_ok=True)
             thread = threading.Thread(
                 target=do_completion_cot,
@@ -168,6 +188,10 @@ def process_cot(test_name: str, api_type="chat"):
             _logger.info(f"Starting chat thread for {bbh_test_path}")
             results_path = generations_dir / "bigbench" / "cot_results" / "chat"
             results_path.mkdir(parents=True, exist_ok=True)
+            if overwrite:
+                cot_results_filename = results_path / f"{subject}_chat_cot_results.json"
+                if os.path.exists(cot_results_filename):
+                    os.remove(cot_results_filename)
             thread = threading.Thread(
                 target=do_chat_cot,
                 args=(bbh_test_path, cot_prompt_path, subject, results_path),

--- a/src/promptbase/bigbench/bigbench_cot.py
+++ b/src/promptbase/bigbench/bigbench_cot.py
@@ -62,7 +62,7 @@ def do_chat_cot(bbh_test_path, cot_prompt_path, test_name, cot_results_path):
             prompt_messages = few_shot_messages + [
                 {"role": "user", "content": "Q: " + example["input"]}
             ]
-            response = text_completion(prompt=prompt_messages, retry_wait=2, max_trial=int(1e9))
+            response = text_completion(prompt=prompt_messages, max_tokens=2000, retry_wait=2, max_trial=int(1e9), api_type="chat")
             if "text" not in response:
                 _logger.error("Error in example %s of test %s response: %s", i, test_name, response)
                 continue
@@ -100,7 +100,7 @@ def do_completion_cot(bbh_test_path, cot_prompt_path, test_name, cot_results_pat
                 continue
             prompt = f"{cot_prompt_contents}\n\nQ: {example['input']}\nA: Let's think step by step.\n"
             try:
-                response = text_completion(prompt=prompt, retry_wait=2, max_trial=int(1e9), stop="\n\n")
+                response = text_completion(prompt=prompt, max_tokens=2000, retry_wait=2, max_trial=int(1e9), stop="\n\n", api_type="completion")
                 test_results.append(
                     {
                         "index": i,

--- a/src/promptbase/bigbench/bigbench_cot.py
+++ b/src/promptbase/bigbench/bigbench_cot.py
@@ -1,11 +1,7 @@
-import logging
-
 import openai
 import os
 import json
-import pathlib
 import time
-import sys
 import threading
 from promptbase.bigbench.consts import BIGBENCH_SUBJECTS
 from promptbase.utils.helpers import text_completion, get_datasets_path, get_generations_path, get_standard_logger_for_file
@@ -25,8 +21,8 @@ def extract_chat_qa(few_shot_prompt):
 
 def do_chat_cot(bbh_test_path, cot_prompt_path, test_name, cot_results_path):
     _logger.info(f"Processing {test_name}")
-    cot_results_filename = os.path.join(cot_results_path, f"{test_name}_chat_cot_results.json")
-    if os.path.exists(cot_results_filename):
+    cot_results_filename = cot_results_path / f"{test_name}_chat_cot_results.json"
+    if cot_results_filename.exists():
         test_results = json.load(open(cot_results_filename, "r"))
     else:
         test_results = []
@@ -82,56 +78,40 @@ def do_chat_cot(bbh_test_path, cot_prompt_path, test_name, cot_results_path):
 
 
 def do_completion_cot(bbh_test_path, cot_prompt_path, test_name, cot_results_path):
-    print(f"Processing {test_name}")
-    test_results = []
+    _logger.info("Processing %s", test_name)
+    cot_results_filename = cot_results_path / f"{test_name}_chat_cot_results.json"
+    if cot_results_filename.exists():
+        test_results = json.load(open(cot_results_filename, "r"))
+    else:
+        test_results = []
     with open(cot_prompt_path, "r", encoding="utf-8") as file:
         cot_prompt_contents = file.read()
         # use everything starting with the third line
         cot_prompt_contents = "\n".join(cot_prompt_contents.split("\n")[2:]).strip()
 
-    print("Chain of thought few-shot prompt:\n", cot_prompt_contents)
+    _logger.info("Chain of thought few-shot prompt: %s", cot_prompt_contents)
 
     with open(bbh_test_path, "r", encoding="utf-8") as file:
         example_data = json.load(file)
         for i, example in enumerate(example_data["examples"]):
-            print(
-                f"Processing example {i} of {len(example_data['examples'])} for {test_name}"
-            )
+            _logger.info(f"Processing example {i} of {len(example_data['examples'])} for {test_name}")
+            if any([r["index"] == i for r in test_results]):
+                _logger.info("Skipping example %s of test %s", i, test_name)
+                continue
             prompt = f"{cot_prompt_contents}\n\nQ: {example['input']}\nA: Let's think step by step.\n"
-            # TODO - use text_completion utils API
-            retry_count = 0
-            max_retries = 5
-            while retry_count < max_retries:
-                retry_count += 1
-                try:
-                    completion = openai.Completion.create(
-                        engine="gemini-compete-wus",
-                        prompt=prompt,
-                        temperature=0,
-                        max_tokens=2000,
-                        top_p=1,
-                        frequency_penalty=0,
-                        presence_penalty=0,
-                        best_of=1,
-                        stop="\n\n",
-                        # stop=["\n\n", "\nQ: ", "\nQ:", "\n\nQ:", "\n\nQ: ", "\nQ: "],
-                    )
-                    test_results.append(
-                        {
-                            "index": i,
-                            "test_name": test_name,
-                            "prompt": prompt,
-                            "completion": completion["choices"][0]["text"],
-                        }
-                    )
-                    break
-                except Exception as e:
-                    _logger.warning("Caught exception: %s", e)
-                    _logger.warning("Retrying in 5 seconds...")
-                    time.sleep(5)
-            cot_results_filename = os.path.join(
-                cot_results_path, f"{test_name}_completion_cot_results.json"
-            )
+            try:
+                response = text_completion(prompt=prompt, retry_wait=2, max_trial=int(1e9), stop="\n\n")
+                test_results.append(
+                    {
+                        "index": i,
+                        "test_name": test_name,
+                        "prompt": prompt,
+                        "completion": response["text"],
+                    }
+                )
+            except Exception as e:
+                _logger.warning("Caught exception: %s", e)
+            cot_results_filename = cot_results_path / f"{test_name}_completion_cot_results.json"
             json.dump(
                 test_results,
                 open(cot_results_filename, "w"),
@@ -146,7 +126,7 @@ def process_cot(test_name: str, overwrite=False, api_type="chat"):
     elif test_name in BIGBENCH_SUBJECTS:
         subjects = [test_name]
     else:
-        print(f"Invalid test name: {test_name}")
+        _logger.error(f"Invalid test name: {test_name}")
         exit(1)
 
     bigbench_data_root = get_datasets_path() / "BigBench"
@@ -154,32 +134,34 @@ def process_cot(test_name: str, overwrite=False, api_type="chat"):
     bbh_test_dir = bigbench_data_root / "bbh"
     generations_dir = get_generations_path()
 
-    if not os.path.exists(cot_prompts_dir):
-        print(f"COT prompt directory {cot_prompts_dir} does not exist")
+    if not cot_prompts_dir.exists():
+        _logger.error(f"COT prompt directory {cot_prompts_dir} does not exist")
         exit(1)
-    elif not os.path.exists(bbh_test_dir):
-        print(f"BBH test directory {bbh_test_dir} does not exist")
+    elif not bbh_test_dir.exists():
+        _logger.error(f"BBH test directory {bbh_test_dir} does not exist")
         exit(1)
 
-    print(f"Processing CoT for BigBench subjects: {subjects}")
+    _logger.info(f"Processing CoT for BigBench subjects: {subjects}")
 
     threads = []
     for subject in subjects:
         bbh_test_path = bbh_test_dir / f"{subject}.json"
         cot_prompt_path = cot_prompts_dir / f"{subject}.txt"
-        if not os.path.exists(bbh_test_path):
-            print(f"Data file {bbh_test_path} does not exist")
-        elif not os.path.exists(cot_prompt_path):
-            print(f"COT prompt file {cot_prompt_path} does not exist")
+        if not bbh_test_path.exists():
+            _logger.error(f"Data file {bbh_test_path} does not exist")
+            exit(1)
+        elif not cot_prompt_path.exists():
+            _logger.error(f"COT prompt file {cot_prompt_path} does not exist")
+            exit(1)
 
         if api_type == "completion":
             _logger.info(f"Starting completion thread for {bbh_test_path}")
             results_path = generations_dir / "bigbench" / "cot_results" / "completion"
             if overwrite:
-                cot_results_filename = results_path / f"{subject}_chat_cot_results.json"
-                if os.path.exists(cot_results_filename):
-                    os.remove(cot_results_filename)
-            os.makedirs(results_path, exist_ok=True)
+                cot_results_filename = results_path / f"{subject}_completion_cot_results.json"
+                if cot_results_filename.exists():
+                    cot_results_filename.unlink()
+            results_path.mkdir(parents=True, exist_ok=True)
             thread = threading.Thread(
                 target=do_completion_cot,
                 args=(bbh_test_path, cot_prompt_path, subject, results_path),
@@ -190,8 +172,8 @@ def process_cot(test_name: str, overwrite=False, api_type="chat"):
             results_path.mkdir(parents=True, exist_ok=True)
             if overwrite:
                 cot_results_filename = results_path / f"{subject}_chat_cot_results.json"
-                if os.path.exists(cot_results_filename):
-                    os.remove(cot_results_filename)
+                if cot_results_filename.exists():
+                    cot_results_filename.unlink()
             thread = threading.Thread(
                 target=do_chat_cot,
                 args=(bbh_test_path, cot_prompt_path, subject, results_path),

--- a/src/promptbase/bigbench/bigbench_cot.py
+++ b/src/promptbase/bigbench/bigbench_cot.py
@@ -79,7 +79,7 @@ def do_chat_cot(bbh_test_path, cot_prompt_path, test_name, cot_results_path):
 
 def do_completion_cot(bbh_test_path, cot_prompt_path, test_name, cot_results_path):
     _logger.info("Processing %s", test_name)
-    cot_results_filename = cot_results_path / f"{test_name}_chat_cot_results.json"
+    cot_results_filename = cot_results_path / f"{test_name}_completion_cot_results.json"
     if cot_results_filename.exists():
         test_results = json.load(open(cot_results_filename, "r"))
     else:

--- a/src/promptbase/bigbench/bigbench_cot.py
+++ b/src/promptbase/bigbench/bigbench_cot.py
@@ -100,7 +100,7 @@ def do_completion_cot(bbh_test_path, cot_prompt_path, test_name, cot_results_pat
                 continue
             prompt = f"{cot_prompt_contents}\n\nQ: {example['input']}\nA: Let's think step by step.\n"
             try:
-                response = text_completion(prompt=prompt, max_tokens=2000, model="gpt4-1106-comp", retry_wait=2, max_trial=int(1e9), stop="\n\n")
+                response = text_completion(prompt=prompt, max_tokens=2000, model="gpt-4-1106-comp", retry_wait=2, max_trial=int(1e9), stop="\n\n")
                 test_results.append(
                     {
                         "index": i,

--- a/src/promptbase/utils/helpers.py
+++ b/src/promptbase/utils/helpers.py
@@ -16,7 +16,8 @@ from tqdm import tqdm
 openai_configs = types.SimpleNamespace()
 
 openai_configs.models = {
-    "gpt-4-1106-preview": {"endpoint": "azure", "type": "chat"},
+    "gpt-4-1106-preview": {"endpoint": "azure_chat", "type": "chat"},
+    "gpt-4-1106-comp": {"endpoint": "azure_comp", "type": "completion"},
     "text-embedding-ada-002": {"endpoint": "openai-embeddings", "type": "embedding"},
 }
 
@@ -25,10 +26,14 @@ openai_configs.endpoints = {
         "headers": {"Authorization": os.getenv("AZURE_OPENAI_API_KEY")},
         "url": os.getenv("AZURE_OPENAI_EMBEDDINGS_URL"),
     },
-    "azure": {
+    "azure_chat": {
         "headers": {"api-key": f"{os.getenv('AZURE_OPENAI_CHAT_API_KEY')}"},
         "url": os.getenv("AZURE_OPENAI_CHAT_ENDPOINT_URL"),
     },
+    "azure_comp": {
+        "headers": {"api-key": f"{os.getenv('AZURE_OPENAI_COMPLETION_API_KEY')}"},
+        "url": os.getenv("AZURE_OPENAI_COMPLETION_ENDPOINT_URL"),
+    }
 }
 
 openai_configs.busy_message = [
@@ -95,7 +100,6 @@ def text_completion_impl(
     frequency_penalty=0.0,
     max_trial=100,
     retry_wait=0.2,
-    api_type: Optional[str]=None,
     **kwargs,
 ):
     """
@@ -112,7 +116,7 @@ def text_completion_impl(
     model_config = openai_configs.models[model]
     endpoint = openai_configs.endpoints[model_config["endpoint"]]
     s = requests.Session()
-    api_type = api_type or model_config["type"]
+    api_type = model_config["type"]
     if api_type == "chat":
         if type(prompt) is list and type(prompt[0]) is str:
             assert len(prompt) == 1  # chat model only support 1 prompt at a time

--- a/src/promptbase/utils/helpers.py
+++ b/src/promptbase/utils/helpers.py
@@ -8,6 +8,7 @@ import random
 import sys
 import time
 import types
+from typing import Optional
 
 import requests
 from tqdm import tqdm
@@ -94,6 +95,7 @@ def text_completion_impl(
     frequency_penalty=0.0,
     max_trial=100,
     retry_wait=0.2,
+    api_type: Optional[str]=None,
     **kwargs,
 ):
     """
@@ -110,13 +112,14 @@ def text_completion_impl(
     model_config = openai_configs.models[model]
     endpoint = openai_configs.endpoints[model_config["endpoint"]]
     s = requests.Session()
-    if model_config["type"] == "chat":
+    api_type = api_type or model_config["type"]
+    if api_type == "chat":
         if type(prompt) is list and type(prompt[0]) is str:
             assert len(prompt) == 1  # chat model only support 1 prompt at a time
             prompt = prompt[0]
         if type(prompt) is str:
             prompt = [{"role": "user", "content": prompt}]
-    elif model_config["type"] == "completion":
+    elif api_type == "completion":
         if type(prompt) is list and type(prompt[0]) is dict:
             prompt = (
                 "".join(

--- a/src/promptbase/utils/helpers.py
+++ b/src/promptbase/utils/helpers.py
@@ -156,7 +156,7 @@ def text_completion_impl(
 
             url = endpoint["url"]
 
-            if model_config["type"] == "chat":
+            if api_type == "chat":
                 payload["messages"] = payload["prompt"]
                 del payload["prompt"], payload["logprobs"], payload["echo"]
 


### PR DESCRIPTION
More fixes and features for bigbench, plus some changes to the shared code base.

Adds 2 new command line arguments:
- mode: Pick chat or completion mode for the test
- overwrite: Choose whether to overwrite the previous generations, i.e. start a fresh run.

It's now possible to stop a bigbench run part-way through and then pick back up where it left off next time. This is very helpful when there are any intermittent errors such as networking issues, or if a few particular generations failed to run properly. The failed generations will be picked up on the next run.