### PR TITLE
Refactor AzureML kNN pipeline

### DIFF
--- a/azureml/components/jsonl_key_filter_component.yaml
+++ b/azureml/components/jsonl_key_filter_component.yaml
@@ -1,0 +1,53 @@
+$schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
+
+name: jsonl_key_filter
+display_name: 'JSONL Key Filter'
+type: command
+description: |
+  Filters keys in JSONL file. Either keeps keys from a specified list, or
+  drops keys from a specified list
+is_deterministic: true
+
+inputs:
+  input_dataset:
+    type: uri_file
+    optional: false
+    description: Dataset containing JSONL input
+  input_encoding:
+    type: string
+    optional: false
+    default: utf-8-sig
+    description: Encoding format of the input dataset
+  keep_keys:
+    type: string
+    optional: true
+    description: Stringified JSON list of keys to keep. Mutually exclusive with drop_keys
+  drop_keys:
+    type: string
+    optional: true
+    description: Stringified JSON list of keys to drop. Mutually exclusive with keep_keys
+  output_encoding:
+    type: string
+    optional: false
+    default: utf-8-sig
+    description: Encoding format of the output dataset
+
+outputs:
+  output_dataset:
+    type: uri_file
+    description: Dataset containing JSONL filtered keys
+
+code: ./src
+
+command: >-
+  python ./jsonl_key_filter.py
+  --input_dataset ${{ inputs.input_dataset }}
+  --input_encoding ${{ inputs.input_encoding }}
+  $[[--keep_keys '${{ inputs.keep_keys }}']]
+  $[[--drop_keys '${{ inputs.drop_keys }}']]
+  --output_dataset ${{ outputs.output_dataset }}
+  --output_encoding ${{ inputs.output_encoding }}
+
+environment:
+  # Will be updated when component uploads
+  image: azureml:promptbase_aml@latest

--- a/azureml/components/jsonl_schema_checker_component.yaml
+++ b/azureml/components/jsonl_schema_checker_component.yaml
@@ -1,0 +1,76 @@
+$schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
+
+name: jsonl_schema_check
+display_name: 'JSONL Schema Check'
+type: command
+description: |
+  Checks lines in a JSONL against a schema, removing those which do not match
+is_deterministic: true
+
+inputs:
+  input_dataset:
+    type: uri_file
+    optional: false
+    description: Dataset containing JSONL input
+  input_encoding:
+    type: string
+    optional: false
+    default: utf-8-sig
+    description: Encoding format of the input dataset
+  schema_dataset:
+    type: uri_file
+    optional: false
+    description: Dataset containing a JSON schema file
+  schema_encoding:
+    type: string
+    optional: false
+    default: utf-8-sig
+    description: Encoding format of the schema dataset
+  forbidden_keys:
+    type: string
+    optional: false
+    default: "[]"
+    description: Stringified JSON list of keys which must not appear in the input
+  max_errors:
+    type: integer
+    optional: false
+    default: 10
+    description: Maximum number of schema errors to tolerate
+  output_encoding:
+    type: string
+    optional: false
+    default: utf-8-sig
+    description: Encoding format of the output dataset
+  error_encoding:
+    type: string
+    optional: false
+    default: utf-8-sig
+    description: Encoding format of the error dataset
+
+
+outputs:
+  output_dataset:
+    type: uri_file
+    description: Dataset containing JSONL filtered keys
+  error_dataset:
+    type: uri_file
+    description: JSONL file containing failed lines
+
+code: ./src
+
+command: >-
+  python ./jsonl_schema_check.py
+  --input_dataset ${{ inputs.input_dataset }}
+  --input_encoding ${{ inputs.input_encoding }}
+  --schema_dataset ${{ inputs.schema_dataset }}
+  --schema_encoding ${{ inputs.schema_encoding }}
+  --forbidden_keys '${{ inputs.forbidden_keys }}'
+  --output_dataset ${{ outputs.output_dataset }}
+  --output_encoding ${{ inputs.output_encoding }}
+  --error_dataset ${{ outputs.error_dataset }}
+  --error_encoding ${{ inputs.error_encoding }}
+  --max_errors ${{ inputs.max_errors }}
+
+environment:
+  # Will be updated when component uploads
+  image: azureml:promptbase_aml@latest

--- a/azureml/components/src/jsonl_key_filter.py
+++ b/azureml/components/src/jsonl_key_filter.py
@@ -1,4 +1,3 @@
-import os
 import argparse
 import functools
 import pathlib

--- a/azureml/components/src/jsonl_key_filter.py
+++ b/azureml/components/src/jsonl_key_filter.py
@@ -1,0 +1,87 @@
+import os
+import argparse
+import functools
+import pathlib
+
+from typing import Any, Dict, List
+
+from shared.argparse_utils import json_loads_fixer
+from shared.jsonl_utils import line_map
+from shared.logging_utils import get_standard_logger_for_file
+
+_logger = get_standard_logger_for_file(__file__)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(add_help=True)
+
+    # Information about the datasets
+    datasets_group = parser.add_argument_group("Datasets")
+    datasets_group.add_argument("--input_dataset", type=pathlib.Path, required=True)
+    datasets_group.add_argument("--input_encoding", type=str, required=True)
+    datasets_group.add_argument("--output_dataset", type=pathlib.Path, required=True)
+    datasets_group.add_argument("--output_encoding", type=str, required=True)
+
+    # Filtering config
+    filtering_group = parser.add_mutually_exclusive_group(required=True)
+    filtering_group.add_argument(
+        "--keep_keys",
+        type=json_loads_fixer,
+        default=[],
+        help="JSON list of keys to keep",
+    )
+    filtering_group.add_argument(
+        "--drop_keys",
+        type=json_loads_fixer,
+        default=[],
+        help="JSON list of keys to drop",
+    )
+
+    args = parser.parse_args()
+    return args
+
+
+def process_item(
+    item: Dict[str, Any], *, keep: List[str], drop: List[str]
+) -> Dict[str, Any]:
+    result = dict()
+
+    if len(keep) > 0:
+        _logger.info("Processing keeps")
+        for k in keep:
+            result[k] = item[k]
+    elif len(drop) > 0:
+        _logger.info("Processing drops")
+        for k, v in item.items():
+            assert k in item, f"Key {k} not in original!"
+            if k not in drop:
+                result[k] = v
+    else:
+        raise ValueError("Shouldn't get here")
+
+    return result
+
+
+def main():
+    args = parse_args()
+
+    # Exclusivity taken care of by add_mutually_exclusive_group
+    assert (
+        len(args.keep_keys) > 0 or len(args.drop_keys) > 0
+    ), "Must either keep or drop something!"
+
+    processor = functools.partial(
+        process_item, keep=args.keep_keys, drop=args.drop_keys
+    )
+
+    line_map(
+        map_func=processor,
+        source_file=args.input_dataset,
+        dest_file=args.output_dataset,
+        source_encoding=args.input_encoding,
+        dest_encoding=args.output_encoding,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/azureml/components/src/jsonl_schema_check.py
+++ b/azureml/components/src/jsonl_schema_check.py
@@ -1,0 +1,64 @@
+import argparse
+import functools
+import pathlib
+
+from typing import Any, Dict, List
+
+from shared.argparse_utils import json_loads_fixer
+from shared.jsonl_utils import line_map
+from shared.logging_utils import get_standard_logger_for_file
+
+_logger = get_standard_logger_for_file(__file__)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(add_help=True)
+
+    # Information about the datasets
+    datasets_group = parser.add_argument_group("Datasets")
+    datasets_group.add_argument("--input_dataset", type=pathlib.Path, required=True)
+    datasets_group.add_argument("--input_encoding", type=str, required=True)
+    datasets_group.add_argument("--schema_dataset", type=pathlib.Path, required=True)
+    datasets_group.add_argument("--schema_encoding", type=str, required=True)
+    datasets_group.add_argument("--output_dataset", type=pathlib.Path, required=True)
+    datasets_group.add_argument("--output_encoding", type=str, required=True)
+    datasets_group.add_argument("--error_dataset", type=pathlib.Path, required=True)
+    datasets_group.add_argument("--error_encoding", type=str, required=True)
+
+    # Forbidden keys
+    parser.add_argument("--forbidden_keys", type=json_loads_fixer, required=True)
+
+    # Maximum error count
+    parser.add_argument("--max_errors", type=int, required=True)
+
+    args = parser.parse_args()
+    return args
+
+
+def process_item(item: Dict[str, Any], *, forbidden_keys=list[str]) -> Dict[str, Any]:
+    for k in forbidden_keys:
+        assert k not in item, f"Key {k} not allowed"
+
+    return item
+
+
+def main():
+    args = parse_args()
+
+    processor = functools.partial(process_item, forbidden_keys=args.forbidden_keys)
+
+    line_map(
+        map_func=processor,
+        source_file=args.input_dataset,
+        dest_file=args.output_dataset,
+        source_encoding=args.input_encoding,
+        dest_encoding=args.output_encoding,
+        error_file=args.error_dataset,
+        error_encoding=args.error_encoding,
+        max_errors=args.max_errors,
+    )
+    _logger.info("Complete")
+
+
+if __name__ == "__main__":
+    main()

--- a/azureml/components/src/shared/argparse_utils.py
+++ b/azureml/components/src/shared/argparse_utils.py
@@ -1,0 +1,16 @@
+import json
+
+from .logging_utils import get_standard_logger_for_file
+
+
+_logger = get_standard_logger_for_file(__file__)
+
+
+def json_loads_fixer(cmd_line_arg: str) -> dict[str, any]:
+    """Parses JSON command line arguments which have acquired extra quotes."""
+    _logger.info(f"Attempting to parse: {cmd_line_arg}")
+    if cmd_line_arg.startswith("'") and cmd_line_arg.endswith("'"):
+        _logger.info("Detected quotes")
+        cmd_line_arg = cmd_line_arg[1:-1]
+        _logger.info(f"Trimmed argument: {cmd_line_arg}")
+    return json.loads(cmd_line_arg)

--- a/azureml/environments/promptbase-env.yaml
+++ b/azureml/environments/promptbase-env.yaml
@@ -18,6 +18,7 @@ conda_file:
       - datasets
       - guidance>0.1.5
       - joblib
+      - jsonschema
       - mlflow
       - numpy
       - openai>=1

--- a/azureml/json_schemas/multichoice_schema.json
+++ b/azureml/json_schemas/multichoice_schema.json
@@ -1,0 +1,32 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "promptbase.multiplechoice",
+    "title": "Multiple Choice Question",
+    "description": "A sample multiple choice question",
+    "type": "object",
+    "properties": {
+        "question": {
+            "description": "The question being asked",
+            "type": "string"
+        },
+        "choices": {
+            "description": "A list of possible answers to the question",
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "minItems": 2,
+            "uniqueItems": true
+        },
+        "correct_answer": {
+            "description": "The index of the correct answer within the 'choices' array",
+            "type": "integer",
+            "minimum": 0
+        }
+    },
+    "required": [
+        "question",
+        "choices",
+        "correct_answer"
+    ]
+}

--- a/azureml/pipelines/azureml_pipelines.py
+++ b/azureml/pipelines/azureml_pipelines.py
@@ -4,8 +4,8 @@ import logging
 from azure.ai.ml import dsl, Input
 from azure.ai.ml.entities import Pipeline
 
-from .azureml_utils import ComponentCollector
-from .constants import AOAIConfig
+from azureml_utils import ComponentCollector
+from configs import AOAIConfig
 
 _logger = logging.getLogger(__file__)
 _logger.setLevel(logging.INFO)

--- a/azureml/pipelines/azureml_pipelines.py
+++ b/azureml/pipelines/azureml_pipelines.py
@@ -12,6 +12,7 @@ _logger.setLevel(logging.INFO)
 
 
 def create_knn_fewshot_pipeline(
+    *,
     components: ComponentCollector,
     embedding_config: AOAIConfig,
     inference_config: AOAIConfig,
@@ -30,12 +31,11 @@ def create_knn_fewshot_pipeline(
         name=f"knn_pipeline",
         display_name=f"Answer with kNN Fewshots",
     )
-    def knn_fewshot(input_ds: Input, example_ds: Input, guidance_prog: Input):
+    def knn_fewshot(guidance_prog: Input, input_ds: Input, example_ds: Input):
         embedding_outputs = dict()
         for k, v in dict(input=input_ds, example=example_ds).items():
-
             embedding_job = components.jsonl_embeddings(
-                input_dataset=v.outputs.output_dataset,
+                input_dataset=v,
                 source_key=question_key,
                 destination_key=embedding_key,
                 workers=embedding_config.workers,
@@ -50,25 +50,25 @@ def create_knn_fewshot_pipeline(
             input_dataset=embedding_outputs["input"],
             example_dataset=embedding_outputs["example"],
             input_vector_key=embedding_key,
-            example_vector_key=embeddings_key,
+            example_vector_key=embedding_key,
             output_key=fewshot_examples_key,
             k_nearest=num_examples,
         )
         knn_job.name = f"select_knn_cosine_similarity"
-        
+
         guidance_job = components.jsonl_guidance(
             guidance_program=guidance_prog,
-            guidance_workers=aoai_config.workers,
-            max_errors=aoai_config.max_errors,
+            guidance_workers=inference_config.workers,
+            max_errors=inference_config.max_errors,
             input_dataset=knn_job.outputs.output_dataset,
-            azure_openai_endpoint=aoai_config.endpoint,
-            azure_openai_deployed_model=aoai_config.model,
+            azure_openai_endpoint=inference_config.endpoint,
+            azure_openai_deployed_model=inference_config.model,
         )
         guidance_job.name = f"guidance_fewshot"
         guidance_job.compute = inference_config.compute_target
 
-        return dict(output_dataset=guidance_job.output.output_dataset)
+        return {"output_dataset": guidance_job.outputs.output_dataset}
 
-    sub_pipeline = knn_fewshot(input_dataset, example_dataset, guidance_program)
+    sub_pipeline = knn_fewshot(guidance_program, input_dataset, example_dataset)
 
     return sub_pipeline

--- a/azureml/pipelines/azureml_pipelines.py
+++ b/azureml/pipelines/azureml_pipelines.py
@@ -31,9 +31,11 @@ def create_knn_fewshot_pipeline(
     embedding_key = "embedding"
     fewshot_examples_key = "fewshot_examples"
 
+    json_schema_file = SCHEMA_DIR / MULTIPLE_CHOICE_SCHEMA_FILE
+    assert (json_schema_file).exists(), f"Failed to find {json_schema_file}"
     multichoice_schema_input = Input(
         type="uri_file",
-        path=SCHEMA_DIR / MULTIPLE_CHOICE_SCHEMA_FILE,
+        path=json_schema_file,
         model="download",
     )
 

--- a/azureml/pipelines/azureml_pipelines.py
+++ b/azureml/pipelines/azureml_pipelines.py
@@ -1,3 +1,4 @@
+import json
 import logging
 
 
@@ -67,7 +68,13 @@ def create_knn_fewshot_pipeline(
         guidance_job.name = f"guidance_fewshot"
         guidance_job.compute = inference_config.compute_target
 
-        return {"output_dataset": guidance_job.outputs.output_dataset}
+        filter_job = components.jsonl_key_filter(
+            input_dataset=guidance_job.outputs.output_dataset,
+            drop_keys=json.dumps([fewshot_examples_key]),
+        )
+        filter_job.name = f"remove_intermediate_keys"
+
+        return {"output_dataset": filter_job.outputs.output_dataset}
 
     sub_pipeline = knn_fewshot(guidance_program, input_dataset, example_dataset)
 

--- a/azureml/pipelines/azureml_pipelines.py
+++ b/azureml/pipelines/azureml_pipelines.py
@@ -1,0 +1,74 @@
+import logging
+
+
+from azure.ai.ml import dsl, Input
+from azure.ai.ml.entities import Pipeline
+
+from .azureml_utils import ComponentCollector
+from .constants import AOAIConfig
+
+_logger = logging.getLogger(__file__)
+_logger.setLevel(logging.INFO)
+
+
+def create_knn_fewshot_pipeline(
+    components: ComponentCollector,
+    embedding_config: AOAIConfig,
+    inference_config: AOAIConfig,
+    input_dataset: Input,
+    example_dataset: Input,
+    guidance_program: Input,
+    num_examples: int,
+) -> Pipeline:
+    _logger.info(f"Starting create_knn_pipeline")
+
+    question_key = "question"
+    embedding_key = "embedding"
+    fewshot_examples_key = "fewshot_examples"
+
+    @dsl.pipeline(
+        name=f"knn_pipeline",
+        display_name=f"Answer with kNN Fewshots",
+    )
+    def knn_fewshot(input_ds: Input, example_ds: Input, guidance_prog: Input):
+        embedding_outputs = dict()
+        for k, v in dict(input=input_ds, example=example_ds).items():
+
+            embedding_job = components.jsonl_embeddings(
+                input_dataset=v.outputs.output_dataset,
+                source_key=question_key,
+                destination_key=embedding_key,
+                workers=embedding_config.workers,
+                max_errors=embedding_config.max_errors,
+                azure_openai_endpoint=embedding_config.endpoint,
+            )
+            embedding_job.compute = embedding_config.compute_target
+            embedding_job.name = f"add_embeddings_{k}"
+            embedding_outputs[k] = embedding_job.outputs.output_dataset
+
+        knn_job = components.jsonl_knn_cosine_similarity(
+            input_dataset=embedding_outputs["input"],
+            example_dataset=embedding_outputs["example"],
+            input_vector_key=embedding_key,
+            example_vector_key=embeddings_key,
+            output_key=fewshot_examples_key,
+            k_nearest=num_examples,
+        )
+        knn_job.name = f"select_knn_cosine_similarity"
+        
+        guidance_job = components.jsonl_guidance(
+            guidance_program=guidance_prog,
+            guidance_workers=aoai_config.workers,
+            max_errors=aoai_config.max_errors,
+            input_dataset=knn_job.outputs.output_dataset,
+            azure_openai_endpoint=aoai_config.endpoint,
+            azure_openai_deployed_model=aoai_config.model,
+        )
+        guidance_job.name = f"guidance_fewshot"
+        guidance_job.compute = inference_config.compute_target
+
+        return dict(output_dataset=guidance_job.output.output_dataset)
+
+    sub_pipeline = knn_fewshot(input_dataset, example_dataset, guidance_program)
+
+    return sub_pipeline

--- a/azureml/pipelines/azureml_utils.py
+++ b/azureml/pipelines/azureml_utils.py
@@ -15,6 +15,7 @@ _logger.setLevel(logging.INFO)
 ALL_COMPONENTS = dict(
     jsonl_embeddings="jsonl_embeddings_aoai_component.yaml",
     jsonl_guidance="jsonl_guidance_component.yaml",
+    jsonl_key_filter="jsonl_key_filter_component.yaml",
     jsonl_knn_cosine_similarity="jsonl_knn_cosine_similarity_component.yaml",
     jsonl_mmlu_fetch="jsonl_mmlu_fetch_component.yaml",
     jsonl_score_multiplechoice="jsonl_score_multiplechoice_component.yaml",

--- a/azureml/pipelines/azureml_utils.py
+++ b/azureml/pipelines/azureml_utils.py
@@ -18,6 +18,7 @@ ALL_COMPONENTS = dict(
     jsonl_key_filter="jsonl_key_filter_component.yaml",
     jsonl_knn_cosine_similarity="jsonl_knn_cosine_similarity_component.yaml",
     jsonl_mmlu_fetch="jsonl_mmlu_fetch_component.yaml",
+    jsonl_schema_checker="jsonl_schema_checker_component.yaml",
     jsonl_score_multiplechoice="jsonl_score_multiplechoice_component.yaml",
     jsonl_to_json="jsonl_to_json_component.yaml",
     uri_folder_to_file="uri_folder_to_file_component.yaml",

--- a/azureml/pipelines/constants.py
+++ b/azureml/pipelines/constants.py
@@ -9,7 +9,7 @@ GUIDANCE_PROGRAMS_DIR = (
 ).absolute()
 
 
-SCHEMA_DIR = (Path(__file__).parent.parent / "schemas").absolute()
+SCHEMA_DIR = (Path(__file__).parent.parent / "json_schemas").absolute()
 
 ENVIRONMENT_FILE = ENVIRONMENTS_DIR / "promptbase-env.yaml"
 

--- a/azureml/pipelines/constants.py
+++ b/azureml/pipelines/constants.py
@@ -8,8 +8,12 @@ GUIDANCE_PROGRAMS_DIR = (
     Path(__file__).parent.parent.parent / "guidance_programs"
 ).absolute()
 
+
+SCHEMA_DIR = (Path(__file__).parent.parent / "schemas").absolute()
+
 ENVIRONMENT_FILE = ENVIRONMENTS_DIR / "promptbase-env.yaml"
 
 assert COMPONENTS_DIR.exists(), f"Did not find {COMPONENTS_DIR}"
 assert ENVIRONMENT_FILE.exists(), f"Did not find {ENVIRONMENT_FILE}"
 assert GUIDANCE_PROGRAMS_DIR.exists(), f"Did not find {GUIDANCE_PROGRAMS_DIR}"
+assert SCHEMA_DIR.exists(), f"Did not find {SCHEMA_DIR}"


### PR DESCRIPTION
Refactor the kNN pipeline so that it is a separately callable thing. This constructs a subpipeline which:

- Accepts a guidance program and two datasets:
  - The `'input_dataset` of questions to be answered
  - The `examples_dataset` of questions to be used as few-shot examples
 - Validates the schema of the two input datasets
 - Computes embeddings for the questions in each dataset
 - Finds a number of nearest neighbours in the `examples_dataset` for each entry in the `input_dataset`
 - Runs the guidance program on each question in the `input_dataset`, providing appropriate examples from the `examples_dataset`
 - Cleans up its intermediate keys from the result