### PR TITLE
AzureML pipeline with kNN fewshot CoT

### DIFF
--- a/azureml/pipelines/azureml_pipelines.py
+++ b/azureml/pipelines/azureml_pipelines.py
@@ -6,7 +6,7 @@ from azure.ai.ml import dsl, Input
 from azure.ai.ml.entities import Pipeline
 
 from azureml_utils import ComponentCollector
-from configs import AOAIConfig, RandomExamplesConfig
+from configs import AOAIConfig, RandomExamplesConfig, KNNConfig
 from constants import SCHEMA_DIR
 
 _logger = logging.getLogger(__file__)
@@ -399,5 +399,128 @@ def create_random_fewshot_cot_pipeline(
         return {"output_dataset": filter_job.outputs.output_dataset}
 
     sub_pipeline = random_fewshot_cot(guidance_program, input_dataset, example_dataset)
+
+    return sub_pipeline
+
+
+
+def create_knn_fewshot_cot_pipeline(
+    *,
+    components: ComponentCollector,
+    inference_config: AOAIConfig,
+    embedding_config: AOAIConfig,
+    input_dataset: Input,
+    example_dataset: Input,
+    guidance_program: Input,
+    knn_config: KNNConfig,
+    output_key: str,
+    cot_key: str,
+) -> Pipeline:
+    _logger.info(f"Starting create_knn_fewshot_cot_pipeline")
+
+    fewshot_examples_key = "fewshot_examples"
+    fewshot_cot_key = "fewshot_cot"
+    fewshot_answer_key = "fewshot_choice"
+    embedding_key = "question_embedding"
+    question_key = "question"
+
+    mc_schema_file = SCHEMA_DIR / MULTIPLE_CHOICE_SCHEMA_FILE
+    assert mc_schema_file.exists(), f"Failed to find {mc_schema_file}"
+    multichoice_schema_input = Input(
+        type="uri_file",
+        path=mc_schema_file,
+        model="download",
+    )
+
+    mc_cot_schema_file = SCHEMA_DIR / MULTIPLE_CHOICE_COT_SCHEMA_FILE
+    assert mc_cot_schema_file.exists(), f"Failed to find {mc_cot_schema_file}"
+    multichoice_cot_schema_input = Input(
+        type="uri_file",
+        path=mc_cot_schema_file,
+        model="download",
+    )
+
+    @dsl.pipeline(
+        name=f"knn_fewshot__cot_pipeline",
+        display_name=f"Answer with kNN Fewshots and CoT",
+    )
+    def knn_fewshot_cot(guidance_prog: Input, input_ds: Input, example_ds: Input):
+        input_schema_job = components.jsonl_schema_checker(
+            input_dataset=input_ds,
+            schema_dataset=multichoice_schema_input,
+            max_errors=inference_config.max_errors,
+            forbidden_keys=json.dumps([fewshot_examples_key, fewshot_answer_key]),
+        )
+        input_schema_job.name = f"check_schema_input"
+
+        example_schema_job = components.jsonl_schema_checker(
+            input_dataset=example_ds,
+            schema_dataset=multichoice_cot_schema_input,
+            max_errors=inference_config.max_errors,
+        )
+        example_schema_job.name = f"check_schema_example"
+
+        embedding_outputs = dict()
+        for k, v in dict(input=input_ds, example=example_ds).items():
+            schema_job = components.jsonl_schema_checker(
+                input_dataset=v,
+                schema_dataset=multichoice_schema_input,
+                max_errors=embedding_config.max_errors,
+                forbidden_keys=json.dumps(
+                    [embedding_key, fewshot_examples_key, fewshot_answer_key]
+                ),
+            )
+            schema_job.name = f"check_schema_{k}"
+
+            embedding_job = components.jsonl_embeddings(
+                input_dataset=schema_job.outputs.output_dataset,
+                source_key=question_key,
+                destination_key=embedding_key,
+                workers=embedding_config.workers,
+                max_errors=embedding_config.max_errors,
+                azure_openai_endpoint=embedding_config.endpoint,
+            )
+            embedding_job.compute = embedding_config.compute_target
+            embedding_job.name = f"add_embeddings_{k}"
+            embedding_outputs[k] = embedding_job.outputs.output_dataset
+
+        knn_job = components.jsonl_knn_cosine_similarity(
+            input_dataset=embedding_outputs["input"],
+            example_dataset=embedding_outputs["example"],
+            input_vector_key=embedding_key,
+            example_vector_key=embedding_key,
+            output_key=fewshot_examples_key,
+            k_nearest=knn_config.k_nearest,
+        )
+        knn_job.name = f"select_knn_cosine_similarity"
+
+        guidance_job = components.jsonl_guidance(
+            guidance_program=guidance_prog,
+            guidance_workers=inference_config.workers,
+            max_errors=inference_config.max_errors,
+            input_dataset=knn_job.outputs.output_dataset,
+            azure_openai_endpoint=inference_config.endpoint,
+            azure_openai_deployed_model=inference_config.model,
+        )
+        guidance_job.name = f"guidance_fewshot"
+        guidance_job.compute = inference_config.compute_target
+
+        rename_job = components.jsonl_key_rename(
+            input_dataset=guidance_job.outputs.output_dataset,
+            rename_keys=json.dumps(
+                {fewshot_answer_key: output_key, fewshot_cot_key: cot_key}
+            ),
+        )
+        rename_job.name = f"rename_output_key"
+
+        filter_job = components.jsonl_key_filter(
+            input_dataset=rename_job.outputs.output_dataset,
+            drop_keys=json.dumps([fewshot_examples_key]),
+        )
+        filter_job.name = f"remove_intermediate_keys"
+
+        return {"output_dataset": filter_job.outputs.output_dataset}
+
+    sub_pipeline = knn_fewshot_cot(guidance_program, input_dataset, example_dataset)
 
     return sub_pipeline

--- a/azureml/pipelines/azureml_pipelines.py
+++ b/azureml/pipelines/azureml_pipelines.py
@@ -403,7 +403,6 @@ def create_random_fewshot_cot_pipeline(
     return sub_pipeline
 
 
-
 def create_knn_fewshot_cot_pipeline(
     *,
     components: ComponentCollector,
@@ -441,7 +440,7 @@ def create_knn_fewshot_cot_pipeline(
     )
 
     @dsl.pipeline(
-        name=f"knn_fewshot__cot_pipeline",
+        name=f"knn_fewshot_cot_pipeline",
         display_name=f"Answer with kNN Fewshots and CoT",
     )
     def knn_fewshot_cot(guidance_prog: Input, input_ds: Input, example_ds: Input):
@@ -461,19 +460,12 @@ def create_knn_fewshot_cot_pipeline(
         example_schema_job.name = f"check_schema_example"
 
         embedding_outputs = dict()
-        for k, v in dict(input=input_ds, example=example_ds).items():
-            schema_job = components.jsonl_schema_checker(
-                input_dataset=v,
-                schema_dataset=multichoice_schema_input,
-                max_errors=embedding_config.max_errors,
-                forbidden_keys=json.dumps(
-                    [embedding_key, fewshot_examples_key, fewshot_answer_key]
-                ),
-            )
-            schema_job.name = f"check_schema_{k}"
-
+        for k, v in dict(
+            input=input_schema_job.outputs.output_dataset,
+            example=example_schema_job.outputs.output_dataset,
+        ).items():
             embedding_job = components.jsonl_embeddings(
-                input_dataset=schema_job.outputs.output_dataset,
+                input_dataset=v,
                 source_key=question_key,
                 destination_key=embedding_key,
                 workers=embedding_config.workers,

--- a/azureml/pipelines/configs.py
+++ b/azureml/pipelines/configs.py
@@ -95,3 +95,15 @@ class RandomFewshotCoTPipelineConfig:
         default_factory=RandomExamplesConfig
     )
     aoai_config: AOAIConfig = field(default_factory=AOAIConfig)
+
+@dataclass
+class KNNFewshotCoTPipelineConfig:
+    pipeline: PipelineConfig = field(default_factory=PipelineConfig)
+    mmlu_dataset: str = str()
+    test_split: str = str()
+    example_split: str = str()
+    zeroshot_cot_guidance_program: str = str()
+    fewshot_cot_guidance_program: str = str()
+    knn_config: KNNConfig = field(default_factory=KNNConfig)
+    aoai_config: AOAIConfig = field(default_factory=AOAIConfig)
+    aoai_embedding_config: AOAIConfig = field(default_factory=AOAIConfig)

--- a/azureml/pipelines/configs/knn_fewshot_cot_config.yaml
+++ b/azureml/pipelines/configs/knn_fewshot_cot_config.yaml
@@ -2,6 +2,7 @@ defaults:
   - _self_
   - aml_config
   - aoai_config
+  - aoai_embedding_config
 
 knn_fewshot_cot_config:
   pipeline:

--- a/azureml/pipelines/configs/knn_fewshot_cot_config.yaml
+++ b/azureml/pipelines/configs/knn_fewshot_cot_config.yaml
@@ -1,0 +1,19 @@
+defaults:
+  - _self_
+  - aml_config
+  - aoai_config
+
+knn_fewshot_cot_config:
+  pipeline:
+    base_experiment_name: fewshot_knn_cot
+    tags:
+    default_compute_target: isolatedcompute
+  mmlu_dataset: college_biology
+  test_split: test
+  example_split: validation
+  zeroshot_cot_guidance_program: zero_shot_cot.py
+  fewshot_cot_guidance_program: fewshot_cot_as_conversation.py
+  knn_config:
+    k_nearest: 5
+  aoai_config: ${ default_aoai_config }
+  aoai_embedding_config: ${ default_aoai_embedding_config }

--- a/azureml/pipelines/configs/knn_fewshot_cot_config.yaml
+++ b/azureml/pipelines/configs/knn_fewshot_cot_config.yaml
@@ -9,7 +9,7 @@ knn_fewshot_cot_config:
     base_experiment_name: fewshot_knn_cot
     tags:
     default_compute_target: isolatedcompute
-  mmlu_dataset: college_biology
+  mmlu_dataset: all_mmlu_datasets
   test_split: test
   example_split: validation
   zeroshot_cot_guidance_program: zero_shot_cot.py

--- a/azureml/pipelines/submit_mmlu_fewshot_knn_cot.py
+++ b/azureml/pipelines/submit_mmlu_fewshot_knn_cot.py
@@ -1,0 +1,164 @@
+# Submit a run using:
+# python .\submit_mmlu_fewshot_knn_cot.py -cn random_knn_cot_config
+
+import time
+
+from dataclasses import dataclass
+
+import hydra
+from hydra.core.config_store import ConfigStore
+
+import omegaconf
+
+from azure.identity import DefaultAzureCredential
+from azure.ai.ml import MLClient
+
+from azure.ai.ml import dsl, Input, MLClient
+from azure.ai.ml.entities import Pipeline
+
+from azureml_pipelines import (
+    create_zeroshot_cot_pipeline,
+    create_knn_fewshot_cot_pipeline,
+)
+from azureml_utils import get_component_collector
+from configs import AMLConfig, KNNFewshotCoTPipelineConfig
+from constants import GUIDANCE_PROGRAMS_DIR
+from logging_utils import get_standard_logger_for_file
+
+_logger = get_standard_logger_for_file(__file__)
+
+
+@dataclass
+class PipelineConfig:
+    random_fewshot_cot_config: KNNFewshotCoTPipelineConfig = omegaconf.MISSING
+    azureml_config: AMLConfig = omegaconf.MISSING
+
+
+cs = ConfigStore.instance()
+cs.store(name="config", node=PipelineConfig)
+
+def create_mmlu_fewshot_knn_cot_pipeline(
+    ml_client: MLClient, run_config: KNNFewshotCoTPipelineConfig, version_string: str
+):
+    components = get_component_collector(ml_client, version_string)
+
+    zeroshot_cot_guidance_program = Input(
+        type="uri_file",
+        path=GUIDANCE_PROGRAMS_DIR / run_config.zeroshot_cot_guidance_program,
+        model="download",
+    )
+
+    fewshot_cot_guidance_program = Input(
+        type="uri_file",
+        path=GUIDANCE_PROGRAMS_DIR / run_config.fewshot_cot_guidance_program,
+        model="download",
+    )
+
+    answer_key = "multiple_choice_answer"
+    cot_key = "chain_of_thought"
+
+    @dsl.pipeline()
+    def basic_pipeline() -> Pipeline:
+        mmlu_fetch_job = components.jsonl_mmlu_fetch(
+            mmlu_dataset=run_config.mmlu_dataset
+        )
+        mmlu_fetch_job.name = f"fetch_mmlu_{run_config.mmlu_dataset}"
+
+        split_outputs = dict()
+        for k, v in dict(
+            input=run_config.test_split, example=run_config.example_split
+        ).items():
+            get_split_job = components.uri_folder_to_file(
+                input_dataset=mmlu_fetch_job.outputs.output_dataset,
+                filename_pattern=f"{v}.jsonl",
+            )
+            get_split_job.name = f"extract_split_{k}"
+            split_outputs[k] = get_split_job.outputs.output_dataset
+
+        # Now, get zero-shot CoTs for the examples
+        example_cot_ds = create_zeroshot_cot_pipeline(
+            pipeline_name=f"zeroshot_cot",
+            pipeline_display_name=f"Zero Shot CoT",
+            components=components,
+            inference_config=run_config.aoai_config,
+            input_dataset=split_outputs["example"],
+            guidance_program=zeroshot_cot_guidance_program,
+            output_key=answer_key,
+            cot_key=cot_key,
+        )
+
+        filter_correct_job = components.jsonl_filter_correct_multiplechoice(
+            input_dataset=example_cot_ds,
+            response_key=answer_key,
+            correct_key="correct_answer",
+        )
+        filter_correct_job.name = f"select_correct_responses"
+
+        answer_ds = create_knn_fewshot_cot_pipeline(
+            components=components,
+            inference_config=run_config.aoai_config,
+            embedding_config=run_config.aoai_embedding_config,
+            input_dataset=split_outputs["input"],
+            example_dataset=filter_correct_job.outputs.output_dataset,
+            guidance_program=fewshot_cot_guidance_program,
+            knn_config=run_config.knn_config,
+            output_key=answer_key,
+            cot_key=cot_key,
+        )
+
+        score_job = components.jsonl_score_multiplechoice(
+            input_dataset=answer_ds,
+            correct_key="correct_answer",  # Set when MMLU fetching
+            response_key=answer_key,
+        )
+        score_job.name = f"fewshot_cot_score"
+
+    
+    pipeline = basic_pipeline()
+    pipeline.experiment_name = (
+        f"{run_config.pipeline.base_experiment_name}_{run_config.mmlu_dataset}"
+    )
+    pipeline.display_name = None
+    pipeline.compute = run_config.pipeline.default_compute_target
+    if run_config.pipeline.tags:
+        pipeline.tags.update(run_config.tags)
+    pipeline.tags.update(
+        {
+            "zeroshot_cot_program": run_config.zeroshot_cot_guidance_program,
+            "fewshot_cot_program": run_config.fewshot_cot_guidance_program,
+        },
+    )
+    _logger.info("Pipeline created")
+
+    return pipeline
+
+
+@hydra.main(config_path="configs", version_base="1.1")
+def main(config: PipelineConfig):
+    version_string = str(int(time.time()))
+    _logger.info(f"AzureML object version for this run: {version_string}")
+
+    _logger.info(f"Azure Subscription: {config.azureml_config.subscription_id}")
+    _logger.info(f"Resource Group: {config.azureml_config.resource_group}")
+    _logger.info(f"Workspace : {config.azureml_config.workspace_name}")
+
+    credential = DefaultAzureCredential(exclude_shared_token_cache_credential=True)
+
+    ws_client = MLClient(
+        credential=credential,
+        subscription_id=config.azureml_config.subscription_id,
+        resource_group_name=config.azureml_config.resource_group,
+        workspace_name=config.azureml_config.workspace_name,
+        logging_enable=False,
+    )
+
+    pipeline = create_mmlu_fewshot_knn_cot_pipeline(
+        ws_client, config.random_fewshot_cot_config, version_string
+    )
+    _logger.info("Submitting pipeline")
+    submitted_job = ws_client.jobs.create_or_update(pipeline)
+    _logger.info(f"Submitted: {submitted_job.name}")
+
+
+if __name__ == "__main__":
+    main()

--- a/azureml/pipelines/submit_mmlu_fewshot_knn_cot.py
+++ b/azureml/pipelines/submit_mmlu_fewshot_knn_cot.py
@@ -1,5 +1,5 @@
 # Submit a run using:
-# python .\submit_mmlu_fewshot_knn_cot.py -cn random_knn_cot_config
+# python .\submit_mmlu_fewshot_knn_cot.py -cn knn_fewshot_cot_config
 
 import time
 
@@ -30,12 +30,13 @@ _logger = get_standard_logger_for_file(__file__)
 
 @dataclass
 class PipelineConfig:
-    random_fewshot_cot_config: KNNFewshotCoTPipelineConfig = omegaconf.MISSING
+    knn_fewshot_cot_config: KNNFewshotCoTPipelineConfig = omegaconf.MISSING
     azureml_config: AMLConfig = omegaconf.MISSING
 
 
 cs = ConfigStore.instance()
 cs.store(name="config", node=PipelineConfig)
+
 
 def create_mmlu_fewshot_knn_cot_pipeline(
     ml_client: MLClient, run_config: KNNFewshotCoTPipelineConfig, version_string: str
@@ -113,7 +114,6 @@ def create_mmlu_fewshot_knn_cot_pipeline(
         )
         score_job.name = f"fewshot_cot_score"
 
-    
     pipeline = basic_pipeline()
     pipeline.experiment_name = (
         f"{run_config.pipeline.base_experiment_name}_{run_config.mmlu_dataset}"
@@ -153,7 +153,7 @@ def main(config: PipelineConfig):
     )
 
     pipeline = create_mmlu_fewshot_knn_cot_pipeline(
-        ws_client, config.random_fewshot_cot_config, version_string
+        ws_client, config.knn_fewshot_cot_config, version_string
     )
     _logger.info("Submitting pipeline")
     submitted_job = ws_client.jobs.create_or_update(pipeline)


### PR DESCRIPTION
Add an AzureML pipeline which provides some examples with chain-of-thought in the main prompt. Starting with an 'example' dataset and a 'test' dataset:

1. Generate CoTs and answers for the example dataset with a zero-shot prompt
2. Filter out examples which had incorrect answers
3. Compute embedding vectors for the 'test' dataset and remaining examples
4. Use cosine similarity to select kNN examples for each entry in the 'test' dataset
5. Use the kNN examples in a few-shot CoT prompt for the test dataset

The `azureml_pipelines.py` file is also getting unwieldly. There is probably a template-pattern refactoring lurking in there, but I have not yet figured out how to do that. 