### PR TITLE
AzureML CoT Ensemble

### DIFF
--- a/azureml/pipelines/configs/knn_fewshot_cot_ensemble_config.yaml
+++ b/azureml/pipelines/configs/knn_fewshot_cot_ensemble_config.yaml
@@ -1,0 +1,22 @@
+# This is also for the submit_mmlu_fewshot_knn_cot.py script
+
+defaults:
+  - _self_
+  - aml_config
+  - aoai_config
+  - aoai_embedding_config
+
+knn_fewshot_cot_config:
+  pipeline:
+    base_experiment_name: fewshot_knn_cot_ensemble
+    tags:
+    default_compute_target: isolatedcompute
+  mmlu_dataset: college_biology
+  test_split: test
+  example_split: validation
+  zeroshot_cot_guidance_program: zero_shot_cot.py
+  fewshot_cot_guidance_program: fewshot_cot_as_conversation_ensemble.py
+  knn_config:
+    k_nearest: 5
+  aoai_config: ${ default_aoai_config }
+  aoai_embedding_config: ${ default_aoai_embedding_config }

--- a/azureml/pipelines/configs/knn_fewshot_cot_ensemble_config.yaml
+++ b/azureml/pipelines/configs/knn_fewshot_cot_ensemble_config.yaml
@@ -11,7 +11,7 @@ knn_fewshot_cot_config:
     base_experiment_name: fewshot_knn_cot_ensemble
     tags:
     default_compute_target: isolatedcompute
-  mmlu_dataset: college_biology
+  mmlu_dataset: all_mmlu_datasets
   test_split: test
   example_split: validation
   zeroshot_cot_guidance_program: zero_shot_cot.py

--- a/guidance_programs/fewshot_cot_as_conversation_ensemble.py
+++ b/guidance_programs/fewshot_cot_as_conversation_ensemble.py
@@ -1,0 +1,122 @@
+import logging
+import sys
+import textwrap
+
+from typing import Any, Dict
+
+import guidance
+from guidance import gen, select, system, user, assistant
+
+
+_logger = logging.getLogger(__file__)
+_logger.setLevel(logging.INFO)
+_logger.addHandler(logging.StreamHandler(stream=sys.stdout))
+
+
+ANSWER_KEY = "string_choice"
+COT_KEY = "explanation"
+
+# Ought to write a generator for this....
+PLAIN_HUNT = [
+    [0, 1, 2, 3],
+    [1, 0, 3, 2],
+    [1, 3, 0, 2],
+    [3, 1, 2, 0],
+    [3, 2, 1, 0],
+    [2, 3, 0, 1],
+    [2, 0, 3, 1],
+    [0, 2, 1, 3],
+]
+
+NUM_PERMUTATIONS = 5
+
+
+@guidance
+def few_shot_cot_multiple_choice(
+    lm: guidance.models.Chat,
+    question: str,
+    choices: list[str],
+    fewshot_examples: list[dict[str, any]],
+    permutation: list[int],
+):
+    # Some general instruction to the model
+    with system():
+        lm += textwrap.dedent(
+            """Answer the following multiple choice **Question**.
+            First, think step by step and write an **Explanation** for reasoning through the question.
+            Then, when prompted by the user for a **Final Answer**, analyze your explanation and write just the number of the correct answer.
+            Do not say the final answer until the user asks for it."""
+        )
+
+    for example in fewshot_examples:
+        with user():
+            lm += "**Question**\n"
+            lm += example["question"] + "\n"
+            for i, choice in enumerate(example["choices"]):
+                lm += f"{i} : {choice}\n"
+            lm += "**Explanation**"
+
+        with assistant():
+            lm += example["chain_of_thought"]
+
+        with user():
+            lm += f"**Final Answer**"
+
+        with assistant():
+            lm += str(example["correct_answer"])
+
+    with user():
+        lm += question + "\n"
+        for i in range(len(choices)):
+            lm += f"{i}: {choices[permutation[i]]}"
+        lm += "**Explanation**"
+
+    with assistant():
+        lm += gen(name=COT_KEY)
+
+    with user():
+        lm += f"**Final Answer**"
+
+    with assistant():
+        lm += select([str(i) for i in range(len(choices))], name=ANSWER_KEY)
+
+    return lm
+
+
+def guidance_generation(
+    lm: guidance.models.Chat,
+    input: Dict[str, Any],
+    common: list[dict[str, Any]] | None = None,
+) -> Dict[str, Any]:
+    _logger.debug("Starting guidance_generation")
+    assert common is None, "Unexpected common data"
+    assert len(input["choices"]) == 4
+
+    votes = [0, 0, 0, 0]
+    cots = []
+    for i in range(NUM_PERMUTATIONS):
+        current_permutation = PLAIN_HUNT[i]
+        result = lm + few_shot_cot_multiple_choice(
+            question=input["question"],
+            choices=input["choices"],
+            fewshot_examples=input["fewshot_examples"],
+            permutation=current_permutation,
+        )
+        _logger.debug(f"Result: {result}")
+        cots.append[result[COT_KEY]]
+        selected = int(result[ANSWER_KEY])
+        actual = current_permutation[selected]
+        votes[actual] += 1
+
+    _logger.debug(f"Votes: {votes}")
+    # Check the votes
+    max_idx = -1
+    curr_max = 0
+    for i in range(len(votes)):
+        if votes[i] > curr_max:
+            curr_max = votes[i]
+            max_idx = i
+
+    final_result = dict(fewshot_choice=max_idx, fewshot_cot=cots)
+    _logger.debug(f"final_result: {final_result}")
+    return final_result

--- a/guidance_programs/fewshot_cot_as_conversation_ensemble.py
+++ b/guidance_programs/fewshot_cot_as_conversation_ensemble.py
@@ -48,9 +48,8 @@ def apply_swaps(line: list[T], swaps: list[int]) -> list[T]:
 
 
 def plain_hunt_generator(starting_line: list[T]) -> Iterator[T]:
-    assert len(starting_line) % 2 == 0, "Must have even number of items"
     first_element = starting_line[0]
-    swaps_A = list(range(0, len(starting_line), 2))
+    swaps_A = list(range(0, len(starting_line) - (len(starting_line) % 2), 2))
     swaps_B = list(range(1, len(starting_line) - 1, 2))
     all_swaps = [swaps_A, swaps_B]
     current = [x for x in starting_line]

--- a/guidance_programs/fewshot_cot_as_conversation_ensemble.py
+++ b/guidance_programs/fewshot_cot_as_conversation_ensemble.py
@@ -2,7 +2,7 @@ import logging
 import sys
 import textwrap
 
-from typing import Any, Dict
+from typing import Any, Dict, Iterator, TypeVar
 
 import guidance
 from guidance import gen, select, system, user, assistant
@@ -28,7 +28,10 @@ def validate_and_sort_swaps(swaps: list[int], line_len: int) -> list[int]:
     return list(sorted(swaps))
 
 
-def apply_swaps(line: list[any], swaps: list[int]) -> list[any]:
+T = TypeVar("T")
+
+
+def apply_swaps(line: list[T], swaps: list[int]) -> list[T]:
     sorted_swaps = validate_and_sort_swaps(swaps, len(line))
 
     i_swap = 0
@@ -44,7 +47,8 @@ def apply_swaps(line: list[any], swaps: list[int]) -> list[any]:
     return result
 
 
-def plain_hunt_generator(starting_line: list[any]):
+def plain_hunt_generator(starting_line: list[T]) -> Iterator[T]:
+    assert len(starting_line) % 2 == 0, "Must have even number of items"
     first_element = starting_line[0]
     swaps_A = list(range(0, len(starting_line), 2))
     swaps_B = list(range(1, len(starting_line) - 1, 2))

--- a/guidance_programs/fewshot_cot_as_conversation_ensemble.py
+++ b/guidance_programs/fewshot_cot_as_conversation_ensemble.py
@@ -9,7 +9,7 @@ from guidance import gen, select, system, user, assistant
 
 
 _logger = logging.getLogger(__file__)
-_logger.setLevel(logging.INFO)
+_logger.setLevel(logging.DEBUG)
 _logger.addHandler(logging.StreamHandler(stream=sys.stdout))
 
 
@@ -103,7 +103,7 @@ def few_shot_cot_multiple_choice(
     with user():
         lm += question + "\n"
         for i in range(len(choices)):
-            lm += f"{i}: {choices[permutation[i]]}"
+            lm += f"{i}: {choices[permutation[i]]}\n"
         lm += "**Explanation**"
 
     with assistant():
@@ -126,9 +126,11 @@ def guidance_generation(
     _logger.debug("Starting guidance_generation")
     assert common is None, "Unexpected common data"
 
-    votes = [0, 0, 0, 0]
+    num_choices = len(input["choices"])
+
+    votes = [0 for _ in range(num_choices)]
     cots = []
-    generator = plain_hunt_generator(list(range(len(input["choices"]))))
+    generator = plain_hunt_generator(list(range(num_choices)))
     for i in range(NUM_PERMUTATIONS):
         current_permutation = next(generator)
         result = lm + few_shot_cot_multiple_choice(

--- a/guidance_programs/fewshot_cot_as_conversation_ensemble.py
+++ b/guidance_programs/fewshot_cot_as_conversation_ensemble.py
@@ -9,7 +9,7 @@ from guidance import gen, select, system, user, assistant
 
 
 _logger = logging.getLogger(__file__)
-_logger.setLevel(logging.DEBUG)
+_logger.setLevel(logging.INFO)
 _logger.addHandler(logging.StreamHandler(stream=sys.stdout))
 
 


### PR DESCRIPTION
Add a new `guidance` program which provides a twist on the fewshot CoT prompt: rather than asking the question once, it asks five times, varying the order of the supplied answers. The answer returned to the main pipeline is the majority vote of these. This can run within the fewshot kNN CoT pipeline, so there is no new `submit_mmlu_` script.