### PR TITLE
Enable 'all' as an MMLU subject

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ To run evaluations, download these datasets and add them to /src/promptbase/data
       - `AZURE_OPENAI_CHAT_API_KEY`
       - `AZURE_OPENAI_CHAT_ENDPOINT_URL`
       - `AZURE_OPENAI_EMBEDDINGS_URL`
+    - Run with `python -m promptbase mmlu --subject <SUBJECT>` where `<SUBJECT>` is one of the MMLU datasets (such as 'abstract_algebra')
+    - In addition to the individual subjects, the `format_mmlu.py` script prepares files which enables `all` to be passed as a subject, which will run on the entire dataset
  - HumanEval: https://huggingface.co/datasets/openai_humaneval
  - DROP: https://allenai.org/data/drop
  - GSM8K: https://github.com/openai/grade-school-math

--- a/src/promptbase/format/format_mmlu.py
+++ b/src/promptbase/format/format_mmlu.py
@@ -6,6 +6,7 @@ import uuid
 
 
 ALL_QUESTIONS = "all_questions.json"
+ALL_FILENAME_FORMAT = "mmlu_all_{0}.json"
 
 
 def parse_arguments():
@@ -55,21 +56,33 @@ def main(mmlu_csv_dir: pathlib.Path, output_path: pathlib.Path):
         test=mmlu_csv_dir / "test",
         val=mmlu_csv_dir / "val",
     )
+    all_questions_split = dict(train=[], dev=[], test=[], val=[])
 
     for split_name, split_path in splits.items():
         for csv_file in split_path.iterdir():
             questions = process_csv_file(csv_file, split_name)
             print(json.dumps(questions[3], indent=4, ensure_ascii=False))
+            file_path = output_path / f"mmlu_{csv_file.stem}.json"
+            print(f"Writing {file_path}")
             with open(
-                output_path / f"mmlu_{csv_file.stem}.json",
+                file_path,
                 "w",
                 encoding="utf-8",
             ) as json_file:
                 json.dump(questions, json_file, ensure_ascii=False, indent=4)
             all_questions.extend(questions)
+            all_questions_split[split_name].extend(questions)
 
+    print("Writing all questions")
     with open(output_path / ALL_QUESTIONS, "w", encoding="utf-8") as json_file:
         json.dump(all_questions, json_file, ensure_ascii=False, indent=4)
+
+    print("Writing all question splits")
+    for split_name, split_questions in all_questions_split.items():
+        file_path = output_path / ALL_FILENAME_FORMAT.format(split_name)
+        print(f"Writing out all questions for split {split_name} to {file_path}")
+        with open(file_path, "w", encoding="utf-8") as json_file:
+            json.dump(split_questions, json_file, ensure_ascii=False, indent=4)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Make it possible to run `promptbase` on the entire MMLU dataset via an `all` subject. This takes a simple "disk space is cheap" approach.